### PR TITLE
fix #9: Use `labelDetails.detail` instead of `label` to detect a trait item

### DIFF
--- a/lua/cmp_lsp_rs/rust/util.lua
+++ b/lua/cmp_lsp_rs/rust/util.lua
@@ -39,14 +39,16 @@ end
 M._inherent = function(e1, e2)
   local c1 = e1.completion_item
   local c2 = e2.completion_item
-  local l1 = c1.label
-  local l2 = c2.label
+
+  -- these may be nil
+  local l1 = c1.labelDetails.detail
+  local l2 = c2.labelDetails.detail
 
   -- both are in scope
   -- then check the inherent items vs trait items
   local pat = " %(as (.*)%)"
-  local trait1 = l1:match(pat)
-  local trait2 = l2:match(pat)
+  local trait1 = string.match(l1 or "", pat)
+  local trait2 = string.match(l2 or "", pat)
 
   if trait1 == nil and trait2 == nil then
     -- both are inherent items, then compare by item name


### PR DESCRIPTION
Fixes #9.

https://github.com/zjp-CN/nvim-cmp-lsp-rs/blob/d6a5249948b0334be361788fe88a81e476e7a7ee/lua/cmp_lsp_rs/rust/util.lua#L39-L49

`_inherent()` should use `labelDetails.detail` instead of `label` when determining that a completion item is a trait item.

Here is an example of actual values of `label` and `labelDetails`.
`label` is a function name and is inappropriate for use here.

```
e1.completion_item.label = "try_into()"
e1.completion_item.labelDetails = {
  description = "fn(self) -> Result<T, <Self as TryInto<T>>::Error>",
  detail = " (as TryInto)"
}
```