### PR TITLE
Add nil checks to `_inherent()`

### DIFF
--- a/lua/cmp_lsp_rs/rust/util.lua
+++ b/lua/cmp_lsp_rs/rust/util.lua
@@ -40,7 +40,6 @@ M._inherent = function(e1, e2)
   local c1 = e1.completion_item
   local c2 = e2.completion_item
 
-  -- Use c1.labelDetails.detail if it is not nil; otherwise, default to c1.label.
   local l1 = c1.label
   if c1.labelDetails and c1.labelDetails.detail then
     l1 = c1.labelDetails.detail

--- a/lua/cmp_lsp_rs/rust/util.lua
+++ b/lua/cmp_lsp_rs/rust/util.lua
@@ -40,15 +40,22 @@ M._inherent = function(e1, e2)
   local c1 = e1.completion_item
   local c2 = e2.completion_item
 
-  -- these may be nil
-  local l1 = c1.labelDetails.detail
-  local l2 = c2.labelDetails.detail
+  -- Use c1.labelDetails.detail if it is not nil; otherwise, default to c1.label.
+  local l1 = c1.label
+  if c1.labelDetails and c1.labelDetails.detail then
+    l1 = c1.labelDetails.detail
+  end
+
+  local l2 = c2.label
+  if c2.labelDetails and c2.labelDetails.detail then
+    l2 = c2.labelDetails.detail
+  end
 
   -- both are in scope
   -- then check the inherent items vs trait items
   local pat = " %(as (.*)%)"
-  local trait1 = string.match(l1 or "", pat)
-  local trait2 = string.match(l2 or "", pat)
+  local trait1 = l1:match(pat)
+  local trait2 = l2:match(pat)
 
   if trait1 == nil and trait2 == nil then
     -- both are inherent items, then compare by item name


### PR DESCRIPTION
The LSP specification states that `CompletionItem.labelDetails` can be nil, so it is better to check that `labelDetails` is not nil before accessing `labelDetails.detail` in `_inherent()`.

The use of `label` was eliminated in the [previous PR](https://github.com/zjp-CN/nvim-cmp-lsp-rs/pull/10), but has been restored in this PR.

This is because I found that rust-analyzer assigns `item.label_detail`, which may contain a string such as `"(as Trait)"` or `"(use Import)"`, to `lsp_item.label` instead of `lsp_item.label_details.detail` if the LSP client does not support the labelDetails capability. ([source code](https://github.com/rust-lang/rust-analyzer/blob/fc98e0657abf3ce07eed513e38274c89bbb2f8ad/crates/rust-analyzer/src/lsp/to_proto.rs#L368-L379))

In other words, we need to handle `label` to support LSP clients that lack support for the labelDetails capability.
